### PR TITLE
Use Convert::Binary::C with native alignment

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Geo::LibProj::FFI
 
+1.01  2025-02-19
+
+ - Fix segmentation fault on armel and armhf. (GH #4) (Andreas Vögele)
+
 1.00  2024-05-12
 
  - Documentation update: Future major changes are no longer expected for this

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2021-2024
 
-version = 1.00
+version = 1.01
 release_status = stable
 
 [@Author::AJNN]

--- a/lib/Geo/LibProj/FFI.pm
+++ b/lib/Geo/LibProj/FFI.pm
@@ -96,7 +96,7 @@ my $ffi = FFI::Platypus->new(
 );
 FFI::C->ffi($ffi);
 
-my $c = Convert::Binary::C->new;
+my $c = Convert::Binary::C->new(Alignment => 0);
 
 $ffi->load_custom_type('::StringPointer' => 'string_pointer');
 # string* should also work, but doesn't in $ffi->cast


### PR DESCRIPTION
This pull request instantiates `Convert::Binary::C` with native alignment. Fixes #4 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1086655.